### PR TITLE
Make Singularize/Pluralize thread-safe

### DIFF
--- a/inflector.go
+++ b/inflector.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 // Rule represents name of the inflector rule, can be
@@ -59,6 +60,8 @@ type compiledRule struct {
 	*regexp.Regexp
 }
 
+// threadsafe access to rules and caches
+var mutex sync.Mutex
 var rules = make(map[Rule]*InflectorRule)
 
 // Words that should not be inflected
@@ -313,6 +316,8 @@ func Singularize(s string) string {
 }
 
 func getInflected(r Rule, s string) string {
+	mutex.Lock()
+	defer mutex.Unlock()
 	if v, ok := caches[r][s]; ok {
 		return v
 	}


### PR DESCRIPTION
This is a great package! Unfortunately, I can't use it in my appengine-deployed project because it's not thread-safe due to the shared usage of the `rules` and `caches` maps. Here's a fairly naive fix to add thread safety. Ran gofmt and tests pass.